### PR TITLE
feature: add prod managed identity with role assignments to dashboard infra

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,3 +36,7 @@
 /plugin/skills/entra-agent-id/ @ArLucaID @RickWinter
 /plugin/skills/entra-app-registration/ @JasonYeMSFT @kvenkatrajan @RickWinter
 /plugin/skills/microsoft-foundry/ @ankitbko @tendau @XOEEst @anchenyi @XiaofuHuang @jugonzales @vebudumu @RickWinter
+/plugin/skills/microsoft-foundry/foundry-agent/create/ @anchenyi @XiaofuHuang @swatDong @RickWinter
+/plugin/skills/microsoft-foundry/foundry-agent/deploy/ @anchenyi @XiaofuHuang @swatDong @RickWinter
+/plugin/skills/microsoft-foundry/foundry-agent/invoke/ @anchenyi @XiaofuHuang @swatDong @RickWinter
+/plugin/skills/microsoft-foundry/foundry-agent/troubleshoot/ @anchenyi @XiaofuHuang @swatDong @RickWinter

--- a/dashboard/infra/main.bicep
+++ b/dashboard/infra/main.bicep
@@ -18,6 +18,15 @@ param msbenchEvalTableName string = 'msbenchevalmetrics'
 @description('Name of the MSBench reports blob container.')
 param msbenchReportsContainerName string = 'msbench-reports'
 
+@description('Subscription ID where the prod managed identity is granted the Contributor role. TODO: replace placeholder before deploying.')
+param prodSubscriptionId string = '00000000-0000-0000-0000-000000000000'
+
+@description('Subscription ID that hosts the existing MSBench nightly data storage account. TODO: replace placeholder before deploying.')
+param msbenchStorageSubscriptionId string = '00000000-0000-0000-0000-000000000000'
+
+@description('Resource group that hosts the existing MSBench nightly data storage account. TODO: replace placeholder before deploying.')
+param msbenchStorageResourceGroupName string = 'rg-msbench-placeholder'
+
 var tags = {
   'azd-env-name': environmentName
   skipDelete: true
@@ -54,6 +63,50 @@ module syncIdentity './modules/managed-identity.bicep' = {
     tags: tags
     environmentName: environmentName
     suffix: '-sync'
+  }
+}
+
+// The prod MI (prodIdentity) has the following permissions:
+// - Contributor on the prod subscription (scope: subscription(prodSubscriptionId)).
+// - Storage Blob Data Contributor + Storage Table Data Contributor on the existing
+//   msbenchnightlydata storage account (where the Function App reads MSBench production data from).
+// - Storage Blob Data Contributor + Storage Table Data Contributor on the dashboard's own
+//   storage account (where integration test workflows write production reports that the
+//   Function App reads from the integration-reports / manual-integration-reports containers).
+module prodIdentity './modules/managed-identity.bicep' = {
+  name: 'prodIdentity'
+  scope: rg
+  params: {
+    location: location
+    tags: tags
+    environmentName: environmentName
+    suffix: '-prod'
+  }
+}
+
+module prodSubscriptionContributorRole './modules/subscription-contributor-role-assignment.bicep' = {
+  name: 'prodSubscriptionContributorRole'
+  scope: subscription(prodSubscriptionId)
+  params: {
+    principalId: prodIdentity.outputs.identityPrincipalId
+  }
+}
+
+module prodMsbenchStorageRoles './modules/storage-data-contributor-role-assignments.bicep' = {
+  name: 'prodMsbenchStorageRoles'
+  scope: resourceGroup(msbenchStorageSubscriptionId, msbenchStorageResourceGroupName)
+  params: {
+    storageAccountName: msbenchStorageAccountName
+    principalId: prodIdentity.outputs.identityPrincipalId
+  }
+}
+
+module prodDashboardStorageRoles './modules/storage-data-contributor-role-assignments.bicep' = {
+  name: 'prodDashboardStorageRoles'
+  scope: rg
+  params: {
+    storageAccountName: storage.outputs.storageAccountName
+    principalId: prodIdentity.outputs.identityPrincipalId
   }
 }
 

--- a/dashboard/infra/modules/storage-data-contributor-role-assignments.bicep
+++ b/dashboard/infra/modules/storage-data-contributor-role-assignments.bicep
@@ -1,0 +1,34 @@
+targetScope = 'resourceGroup'
+
+@description('Name of the existing storage account to grant Storage Blob/Table Data Contributor roles on.')
+param storageAccountName string
+
+@description('Principal ID of the managed identity to assign Storage Blob/Table Data Contributor roles to.')
+param principalId string
+
+var storageBlobDataContributorRoleId = 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
+var storageTableDataContributorRoleId = '0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3'
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
+  name: storageAccountName
+}
+
+resource storageBlobDataContributorRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(storageAccount.id, principalId, storageBlobDataContributorRoleId)
+  scope: storageAccount
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageBlobDataContributorRoleId)
+    principalId: principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource storageTableDataContributorRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(storageAccount.id, principalId, storageTableDataContributorRoleId)
+  scope: storageAccount
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageTableDataContributorRoleId)
+    principalId: principalId
+    principalType: 'ServicePrincipal'
+  }
+}

--- a/dashboard/infra/modules/subscription-contributor-role-assignment.bicep
+++ b/dashboard/infra/modules/subscription-contributor-role-assignment.bicep
@@ -1,0 +1,15 @@
+targetScope = 'subscription'
+
+@description('Principal ID of the managed identity to assign the Contributor role to at subscription scope.')
+param principalId string
+
+var contributorRoleId = 'b24988ac-6180-42a0-ab88-20f7382dd24c'
+
+resource contributorRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(subscription().id, principalId, contributorRoleId)
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', contributorRoleId)
+    principalId: principalId
+    principalType: 'ServicePrincipal'
+  }
+}


### PR DESCRIPTION
## Description

Adds a new user-assigned managed identity (`prodIdentity`) to the dashboard Bicep templates with the following role assignments:

- **Contributor** at subscription scope (`prodSubscriptionId` placeholder param — fill in before deploying).
- **Storage Blob Data Contributor** + **Storage Table Data Contributor** on the existing external `msbenchnightlydata` storage account, located via placeholder params `msbenchStorageSubscriptionId` / `msbenchStorageResourceGroupName`.
- **Storage Blob Data Contributor** + **Storage Table Data Contributor** on the dashboard's own storage account (from `storage.bicep`), where the integration test GitHub workflows (`test-all-integration.yml`, `test-azure-deploy.yml`) upload production reports and the Function App reads them via `api/src/blobEnumerator.ts`.

New modules:
- `dashboard/infra/modules/subscription-contributor-role-assignment.bicep` — assigns Contributor at subscription scope.
- `dashboard/infra/modules/storage-data-contributor-role-assignments.bicep` — generic helper that grants Blob + Table Data Contributor on an existing storage account (used twice from `main.bicep`).

Validated locally with `az bicep build` (clean compile; only pre-existing tag-type warnings on the `tags` object, unrelated to this change).

## Checklist

- [x] Tests pass locally (`cd tests && npm test`) — N/A, no test code touched
- [x] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [x] **If modifying skill descriptions:** verified routing correctness with integration tests — N/A, no skill descriptions touched

## Related Issues

None.
