### PR TITLE
feat: (dashboard) add CI managed identity with contributor + storage data roles

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,3 +36,7 @@
 /plugin/skills/entra-agent-id/ @ArLucaID @RickWinter
 /plugin/skills/entra-app-registration/ @JasonYeMSFT @kvenkatrajan @RickWinter
 /plugin/skills/microsoft-foundry/ @ankitbko @tendau @XOEEst @anchenyi @XiaofuHuang @jugonzales @vebudumu @RickWinter
+/plugin/skills/microsoft-foundry/foundry-agent/create/ @anchenyi @XiaofuHuang @swatDong @RickWinter
+/plugin/skills/microsoft-foundry/foundry-agent/deploy/ @anchenyi @XiaofuHuang @swatDong @RickWinter
+/plugin/skills/microsoft-foundry/foundry-agent/invoke/ @anchenyi @XiaofuHuang @swatDong @RickWinter
+/plugin/skills/microsoft-foundry/foundry-agent/troubleshoot/ @anchenyi @XiaofuHuang @swatDong @RickWinter

--- a/dashboard/infra/main.bicep
+++ b/dashboard/infra/main.bicep
@@ -18,6 +18,12 @@ param msbenchEvalTableName string = 'msbenchevalmetrics'
 @description('Name of the MSBench reports blob container.')
 param msbenchReportsContainerName string = 'msbench-reports'
 
+@description('Subscription ID where the CI managed identity should receive the Contributor role. TODO: replace placeholder with the real subscription ID.')
+param ciContributorSubscriptionId string = '00000000-0000-0000-0000-000000000000'
+
+@description('Resource group containing the existing MSBench nightly data storage account. TODO: replace placeholder with the real resource group name.')
+param msbenchStorageResourceGroupName string = 'rg-msbench-placeholder'
+
 var tags = {
   'azd-env-name': environmentName
   skipDelete: true
@@ -57,6 +63,40 @@ module syncIdentity './modules/managed-identity.bicep' = {
   }
 }
 
+// The CI MI (ciIdentity) is used by CI pipelines that need to:
+// - Manage resources in the target subscription (Contributor at subscription scope).
+// - Write blobs and table entities in the dashboard storage account
+//   (Storage Blob Data Contributor + Storage Table Data Contributor).
+module ciIdentity './modules/managed-identity.bicep' = {
+  name: 'ciIdentity'
+  scope: rg
+  params: {
+    location: location
+    tags: tags
+    environmentName: environmentName
+    suffix: '-ci'
+  }
+}
+
+module ciSubscriptionContributor './modules/subscription-role-assignment.bicep' = {
+  name: 'ciSubscriptionContributor'
+  scope: subscription(ciContributorSubscriptionId)
+  params: {
+    principalId: ciIdentity.outputs.identityPrincipalId
+    // Contributor
+    roleDefinitionId: 'b24988ac-6180-42a0-ab88-20f7382dd24c'
+  }
+}
+
+module ciMsbenchStorageRoles './modules/msbench-storage-role-assignments.bicep' = {
+  name: 'ciMsbenchStorageRoles'
+  scope: resourceGroup(msbenchStorageResourceGroupName)
+  params: {
+    storageAccountName: msbenchStorageAccountName
+    ciPrincipalId: ciIdentity.outputs.identityPrincipalId
+  }
+}
+
 module storage './modules/storage.bicep' = {
   scope: rg
   params: {
@@ -64,6 +104,7 @@ module storage './modules/storage.bicep' = {
     tags: tags
     environmentName: environmentName
     principalId: identity.outputs.identityPrincipalId
+    ciPrincipalId: ciIdentity.outputs.identityPrincipalId
   }
 }
 

--- a/dashboard/infra/modules/msbench-storage-role-assignments.bicep
+++ b/dashboard/infra/modules/msbench-storage-role-assignments.bicep
@@ -1,0 +1,34 @@
+targetScope = 'resourceGroup'
+
+@description('Name of the existing storage account to grant roles on.')
+param storageAccountName string
+
+@description('Principal ID of the CI managed identity to assign Blob and Table Data Contributor roles.')
+param ciPrincipalId string
+
+var storageBlobDataContributorRoleId = 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
+var storageTableDataContributorRoleId = '0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3'
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
+  name: storageAccountName
+}
+
+resource ciStorageBlobDataContributorRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(storageAccount.id, ciPrincipalId, storageBlobDataContributorRoleId)
+  scope: storageAccount
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageBlobDataContributorRoleId)
+    principalId: ciPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource ciStorageTableDataContributorRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(storageAccount.id, ciPrincipalId, storageTableDataContributorRoleId)
+  scope: storageAccount
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageTableDataContributorRoleId)
+    principalId: ciPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}

--- a/dashboard/infra/modules/storage.bicep
+++ b/dashboard/infra/modules/storage.bicep
@@ -12,9 +12,14 @@ param environmentName string
 @description('Principal ID of the managed identity to assign the Storage Blob Data Reader role.')
 param principalId string
 
+@description('Principal ID of the CI managed identity to assign Blob and Table Data Contributor roles.')
+param ciPrincipalId string
+
 var resourceSuffix = take(uniqueString(subscription().id, resourceGroup().name, environmentName), 6)
 var storagePrefix = take(replace(environmentName, '-', ''), 14)
 var storageBlobDataReaderRoleId = '2a2b9908-6ea1-4ae2-8e65-a410df84e7d1'
+var storageBlobDataContributorRoleId = 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
+var storageTableDataContributorRoleId = '0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3'
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
   name: 'str${storagePrefix}${resourceSuffix}'
@@ -85,6 +90,26 @@ resource storageBlobDataReaderRole 'Microsoft.Authorization/roleAssignments@2022
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageBlobDataReaderRoleId)
     principalId: principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource ciStorageBlobDataContributorRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(storageAccount.id, ciPrincipalId, storageBlobDataContributorRoleId)
+  scope: storageAccount
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageBlobDataContributorRoleId)
+    principalId: ciPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource ciStorageTableDataContributorRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(storageAccount.id, ciPrincipalId, storageTableDataContributorRoleId)
+  scope: storageAccount
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageTableDataContributorRoleId)
+    principalId: ciPrincipalId
     principalType: 'ServicePrincipal'
   }
 }

--- a/dashboard/infra/modules/subscription-role-assignment.bicep
+++ b/dashboard/infra/modules/subscription-role-assignment.bicep
@@ -1,0 +1,16 @@
+targetScope = 'subscription'
+
+@description('Principal ID of the managed identity receiving the role.')
+param principalId string
+
+@description('Role definition GUID to assign at the subscription scope.')
+param roleDefinitionId string
+
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(subscription().id, principalId, roleDefinitionId)
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', roleDefinitionId)
+    principalId: principalId
+    principalType: 'ServicePrincipal'
+  }
+}


### PR DESCRIPTION
## Description

Adds a third user-assigned managed identity (`ciIdentity`, suffix `-ci`) to the dashboard Bicep templates, intended for CI pipelines that deploy/manage resources and write production data.

Role assignments granted to the new MI:
- **Contributor** at the subscription scope `ciContributorSubscriptionId` (new parameter, placeholder default — must be set to the real subscription GUID before deployment).
- **Storage Blob Data Contributor** + **Storage Table Data Contributor** on the dashboard storage account created in `storage.bicep`.
- **Storage Blob Data Contributor** + **Storage Table Data Contributor** on the existing `msbenchnightlydata` storage account, scoped via the new `msbenchStorageResourceGroupName` parameter (placeholder default — must be set to the real resource group name before deployment).

New modules:
- `modules/subscription-role-assignment.bicep` — generic subscription-scoped role assignment.
- `modules/msbench-storage-role-assignments.bicep` — grants the two data-plane roles on the existing MSBench storage account.

Verified locally with `az bicep build`.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [x] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests

## Related Issues

<!-- None -->