### PR TITLE
fix: exclude evals/ from dependabot pip dependency tracking

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,4 +53,12 @@ updates:
   schedule:
     day: monday
     interval: weekly
+- directories:
+  - "/evals/**"
+  ignore:
+  - dependency-name: "*" # evals/ contains test fixtures only; suppress all dependency updates
+  open-pull-requests-limit: 0
+  package-ecosystem: pip
+  schedule:
+    interval: weekly
 version: 2


### PR DESCRIPTION
## Summary

Excludes the `evals/` directory from dependabot pip dependency tracking. The `evals/` folder contains test fixtures with `requirements.txt` files (e.g., for Python app fixtures) that should not trigger dependabot PRs.

## Changes

Added a new `pip` ecosystem entry to `.github/dependabot.yml` that:
- Targets `/evals/**` using the `directories` glob pattern
- Ignores all dependencies (`dependency-name: "*"`)
- Sets `open-pull-requests-limit: 0`

## Context

Ref: microsoft/GitHub-Copilot-for-Azure#2635 - dependabot opened a PR to bump a Python dependency used only in eval test fixtures.