### PR TITLE
chore: ignore @types/node in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
   - dependency-name: "*"
     update-types:
     - version-update:semver-patch
+  - dependency-name: "@types/node" # @types/node versions mirror Node.js versions; pin manually
   open-pull-requests-limit: 10
   package-ecosystem: npm
   schedule:
@@ -22,6 +23,7 @@ updates:
   - dependency-name: "*"
     update-types:
     - version-update:semver-patch
+  - dependency-name: "@types/node" # @types/node versions mirror Node.js versions; pin manually
   open-pull-requests-limit: 5
   package-ecosystem: npm
   schedule:
@@ -36,6 +38,7 @@ updates:
   - dependency-name: "*"
     update-types:
     - version-update:semver-patch
+  - dependency-name: "@types/node" # @types/node versions mirror Node.js versions; pin manually
   open-pull-requests-limit: 5
   package-ecosystem: npm
   schedule:


### PR DESCRIPTION
## Summary

Adds a Dependabot ignore rule for `@types/node` across all three npm package ecosystem entries (`/`, `/scripts`, `/tests`).

`@types/node` versions mirror Node.js major versions — bumping them without intentionally upgrading the Node.js runtime causes type mismatches. These should be pinned and updated manually.

## Related PRs to close

The following Dependabot PRs were incorrectly opened and should be abandoned after this merges:
- microsoft/GitHub-Copilot-for-Azure#2716
- microsoft/GitHub-Copilot-for-Azure#2714
- microsoft/GitHub-Copilot-for-Azure#2712